### PR TITLE
Fix input validation for numeric options

### DIFF
--- a/src/CacheCleaner.ts
+++ b/src/CacheCleaner.ts
@@ -107,6 +107,12 @@ export class CacheCleaner {
         'Env variables NICC_FULLNESS_PERCENT and NICC_MAX_CAPACITY cannot be defined separately!',
       )
     }
+    if (Number.isNaN(directorySize)) {
+      throw new RangeError('Env variable NICC_MAX_CAPACITY must be a valid number!')
+    }
+    if (Number.isNaN(fullnessPercent)) {
+      throw new RangeError('Env variable NICC_FULLNESS_PERCENT must be a valid number!')
+    }
     if (typeof directorySize === 'number' && directorySize <= 0) {
       throw new RangeError(
         'Env variable NICC_MAX_CAPACITY must be greater than 0!',
@@ -125,7 +131,7 @@ export class CacheCleaner {
         'Env NICC_FULLNESS_PERCENT must be a fractional value in the range (0, 1)!',
       )
     }
-    if (directoryPath === '') {
+    if (!directoryPath) {
       throw new Error('Env NICC_IMAGE_CACHE_DIRECTORY cannot be empty!')
     }
   }

--- a/src/parseInputArgs.ts
+++ b/src/parseInputArgs.ts
@@ -39,15 +39,27 @@ export const parseInputArgs = (): CacheCleanerConstructorParams => {
     config = {
       cronString: process.env.NICC_CRON_CONFIG,
       directoryPath: process.env.NICC_IMAGE_CACHE_DIRECTORY,
-      directorySize: Number(process.env.NICC_MAX_CAPACITY),
-      fullnessPercent: Number(process.env.NICC_FULLNESS_PERCENT),
+      directorySize:
+        process.env.NICC_MAX_CAPACITY && process.env.NICC_MAX_CAPACITY !== ''
+          ? Number(process.env.NICC_MAX_CAPACITY)
+          : undefined,
+      fullnessPercent:
+        process.env.NICC_FULLNESS_PERCENT && process.env.NICC_FULLNESS_PERCENT !== ''
+          ? Number(process.env.NICC_FULLNESS_PERCENT)
+          : undefined,
     }
   } else {
     config = {
       cronString: inputs.cron,
       directoryPath: inputs.dir,
-      directorySize: Number(inputs.size),
-      fullnessPercent: Number(inputs.percent),
+      directorySize:
+        inputs.size !== undefined && inputs.size !== ''
+          ? Number(inputs.size)
+          : undefined,
+      fullnessPercent:
+        inputs.percent !== undefined && inputs.percent !== ''
+          ? Number(inputs.percent)
+          : undefined,
     }
   }
 


### PR DESCRIPTION
## Summary
- handle missing or empty CLI/env inputs when parsing arguments
- validate that numeric parameters are finite numbers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/js)*
- `npm run ts-check` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685da0e2e88483288acab657821c371a