### PR TITLE
fix(logger): handle missing pino-pretty dependency gracefully

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 build
 coverage
 dist
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ volumes:
 - **Watcher Mode:**
   With [Chokidar](https://www.npmjs.com/package/chokidar), the tool listens for new files in the cache directory and triggers cleanup when necessary. Debouncing is applied to prevent excessive cleanups.
 
+**Pretty Logs:**
+
+If you want to see beautifully formatted logs with color highlighting, install `pino-pretty` as an additional dependency:
+
+```shell
+npm install pino-pretty
+# or
+yarn add pino-pretty
+```
+
+After installation, logs will be automatically formatted with colors and human-readable output. Without `pino-pretty`, logs are output in JSON format, which is suitable for production environments and monitoring systems.
+
 ### Parameter Validation
 
 - All numeric parameters are strictly validated. If a value is missing, empty, or not a valid number, it will be ignored and the corresponding feature will be disabled or an error will be thrown (if required).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import tseslint from 'typescript-eslint'
 /** @type {import("eslint").Linter.Config[]} */
 export default [
   { files: ['**/*.{js,mjs,cjs,ts}'] },
+  { ignores: ['CHANGELOG.md'] },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,33 @@
-/* v8 ignore next 14 */
+/* v8 ignore next 34 */
 import pino, { LevelOrString } from 'pino'
 
-export const createLoggerInstance = (logLevel: LevelOrString) =>
-  pino({
-    level: logLevel,
-    transport: {
-      target: 'pino-pretty',
-      options: {
-        colorize: true,
+/**
+ * Creates a pino logger instance with optional pretty formatting.
+ *
+ * This function attempts to create a logger with pino-pretty transport for formatted output.
+ * If pino-pretty is not available (e.g., when installed via npx), it gracefully falls back
+ * to a basic pino logger that outputs JSON format suitable for production environments.
+ *
+ * @param {LevelOrString} logLevel - The log level (debug, info, warn, error, etc.)
+ * @returns {pino.Logger} A configured pino logger instance
+ */
+export const createLoggerInstance = (logLevel: LevelOrString) => {
+  try {
+    // Try to create logger with pino-pretty transport for formatted output
+    return pino({
+      level: logLevel,
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+        },
       },
-    },
-  })
+    })
+  } catch (error) {
+    console.error('Error creating logger instance:', error)
+    // Fallback to basic pino logger if pino-pretty is not available
+    return pino({
+      level: logLevel,
+    })
+  }
+}


### PR DESCRIPTION
- Add fallback to basic pino logger when pino-pretty is not available
- Prevent "unable to determine transport target" error when running via npx
- Add comprehensive documentation about pretty logs installation
- Include JSDoc comments for better code documentation

Resolves issue with users getting transport target errors when using npx